### PR TITLE
Upgrade redis dependency

### DIFF
--- a/finicity-ruby.gemspec
+++ b/finicity-ruby.gemspec
@@ -54,13 +54,12 @@ Gem::Specification.new do |s|
   s.add_development_dependency(%q<rake>.freeze, ["~> 10.0"])
   s.add_development_dependency(%q<rspec>.freeze, ["~> 3.0"])
   s.add_development_dependency(%q<rubocop>.freeze, [">= 0"])
-  s.add_development_dependency 'fakeredis', '~> 0.7.0'
+  # s.add_development_dependency 'fakeredis'
   s.add_development_dependency 'awesome_print', '1.8.0'
   s.add_development_dependency 'byebug', '10.0.2'
 
   s.add_runtime_dependency(%q<hashie>.freeze, ["~> 3.4.4"])
   s.add_runtime_dependency(%q<httparty>.freeze, ["~> 0.14.0"])
-  s.add_runtime_dependency(%q<redis>.freeze, ["~> 3.3.1"])
+  s.add_runtime_dependency(%q<redis>.freeze, ['~> 4.1.3'])
   s.add_runtime_dependency(%q<activesupport>.freeze, [">= 0"])
-
 end


### PR DESCRIPTION
Comment out fakeredis dependency because new versions haven't been released of it for redis 4+